### PR TITLE
Fix an issue with lookitem when parsing OTXML (typeex).

### DIFF
--- a/source/creatures.cpp
+++ b/source/creatures.cpp
@@ -159,7 +159,8 @@ CreatureType* CreatureType::loadFromOTXML(const FileName& filename, pugi::xml_do
 			ct->outfit.lookType = pugi::cast<int32_t>(attribute.value());
 		}
 
-		if ((attribute = optionNode.attribute("item")) || (attribute = optionNode.attribute("lookex"))) {
+        if ((attribute = optionNode.attribute("item")) || (attribute = optionNode.attribute("lookex")) 
+                || (attribute = optionNode.attribute("typeex"))) {
 			ct->outfit.lookItem = pugi::cast<int32_t>(attribute.value());
 		}
 


### PR DESCRIPTION
Simple patch as stated in the title.
Fixes the parsing on monsters/npc's when importing ones with typeex attribute.