### PR TITLE
support for 10.92,10.93 and 10.94 on the sources

### DIFF
--- a/source/client_version.cpp
+++ b/source/client_version.cpp
@@ -247,8 +247,10 @@ void ClientVersion::loadVersion(pugi::xml_node versionNode)
 				client_data.datFormat = DAT_FORMAT_1050;
 			} else if(format == "10.57") {
 				client_data.datFormat = DAT_FORMAT_1057;
+			} else if (format == "10.92") {
+				client_data.datFormat = DAT_FORMAT_1092;
 			} else {
-				wxLogError(wxT("Node 'data' 'format' is invalid (7.4, 7.55, 7.8, 8.6, 9.6, 10.10, 10.50 and 10.57 are supported)"));
+				wxLogError(wxT("Node 'data' 'format' is invalid (7.4, 7.55, 7.8, 8.6, 9.6, 10.10, 10.50, 10.57 and 10.92 are supported)"));
 				continue;
 			}
 

--- a/source/client_version.h
+++ b/source/client_version.h
@@ -117,7 +117,8 @@ enum DatFormat
 	DAT_FORMAT_96,
 	DAT_FORMAT_1010,
 	DAT_FORMAT_1050,
-	DAT_FORMAT_1057
+	DAT_FORMAT_1057,
+	DAT_FORMAT_1092
 };
 
 enum DatFlags : uint8_t
@@ -157,6 +158,9 @@ enum DatFlags : uint8_t
 	DatFlagCloth = 32,
 	DatFlagMarket = 33,
 	DatFlagUsable = 34,
+	DatFlagWrappable = 35,
+	DatFlagUnwrappable = 36,
+	DatFlagTopEffect = 37,
 
 	DatFlagFloorChange = 252,
 	DatFlagNoMoveAnimation = 253, // 10.10: real value is 16, but we need to do this for backwards compatibility

--- a/source/graphics.cpp
+++ b/source/graphics.cpp
@@ -575,6 +575,9 @@ bool GraphicManager::loadSpriteMetadataFlags(FileReadHandle& file, GameSprite* s
 			case DatFlagAnimateAlways:
 			case DatFlagFullGround:
 			case DatFlagLook:
+			case DatFlagWrappable:
+			case DatFlagUnwrappable:
+			case DatFlagTopEffect:
 			case DatFlagFloorChange:
 			case DatFlagNoMoveAnimation:
 			case DatFlagChargeable:


### PR DESCRIPTION
Its missing the clients.xml and the data folders because there is no oficial otb from the oficial tfs project. This was meant to help people that wants to support latest client without errors.
@Mignari 