### PR TITLE
Find libarchive on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
 
 find_package(OpenGL REQUIRED)
+
+if(APPLE)
+    set(CMAKE_PREFIX_PATH /usr/local/opt/libarchive)
+endif()
 find_package(LibArchive REQUIRED)
 
 if(WIN32)


### PR DESCRIPTION
MacOS already provides libarchive and installing another version in parallel can cause trouble. So when installing the latest libarchive using brew it is placed in /usr/local/opt/libarchive instead of /usr/local. Setting CMAKE_PREFIX_PATH to /usr/local/opt/libarchive will make find_package actually find the library.