### PR TITLE
Fix problems when editing houses on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ cmake_install.cmake
 Makefile
 build/
 build.*/
+build-debug
+build-release
 CMakeLists.txt.user*
 
 # RME

--- a/source/palette_house.cpp
+++ b/source/palette_house.cpp
@@ -411,7 +411,9 @@ void HousePalettePanel::OnClickRemoveHouse(wxCommandEvent& event)
 			house_list->SetSelection(selection);
 		} else {
 			select_position_button->Enable(false);
+			select_position_button->SetValue(false);
 			house_brush_button->Enable(false);
+			house_brush_button->SetValue(false);
 			edit_house_button->Enable(false);
 			remove_house_button->Enable(false);
 		}

--- a/source/palette_house.cpp
+++ b/source/palette_house.cpp
@@ -70,9 +70,10 @@ HousePalettePanel::HousePalettePanel(wxWindow* parent, wxWindowID id) :
 	sidesizer->Add(house_list, 1, wxEXPAND);
 
 	tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
-	tmpsizer->Add(add_house_button = newd wxButton(this, PALETTE_HOUSE_ADD_HOUSE, wxT("Add"), wxDefaultPosition, wxSize(50, -1)), wxSizerFlags(1).Right());
-	tmpsizer->Add(edit_house_button = newd wxButton(this, PALETTE_HOUSE_EDIT_HOUSE, wxT("Edit"), wxDefaultPosition, wxSize(50, -1)), wxSizerFlags(1).Right());
-	tmpsizer->Add(remove_house_button = newd wxButton(this, PALETTE_HOUSE_REMOVE_HOUSE, wxT("Remove"), wxDefaultPosition, wxSize(70, -1)), wxSizerFlags(1).Right());
+	wxSizerFlags sizerFlags(1);
+	tmpsizer->Add(add_house_button = newd wxButton(this, PALETTE_HOUSE_ADD_HOUSE, wxT("Add"), wxDefaultPosition, wxSize(50, -1)), sizerFlags);
+	tmpsizer->Add(edit_house_button = newd wxButton(this, PALETTE_HOUSE_EDIT_HOUSE, wxT("Edit"), wxDefaultPosition, wxSize(50, -1)), sizerFlags);
+	tmpsizer->Add(remove_house_button = newd wxButton(this, PALETTE_HOUSE_REMOVE_HOUSE, wxT("Remove"), wxDefaultPosition, wxSize(70, -1)), sizerFlags);
 	sidesizer->Add(tmpsizer, wxSizerFlags(0).Right());
 
 	topsizer->Add(sidesizer, 1, wxEXPAND);

--- a/source/palette_house.cpp
+++ b/source/palette_house.cpp
@@ -66,7 +66,7 @@ HousePalettePanel::HousePalettePanel(wxWindow* parent, wxWindowID id) :
 	town_choice = newd wxChoice(this, PALETTE_HOUSE_TOWN_CHOICE, wxDefaultPosition, wxDefaultSize, (int)0, (const wxString*)nullptr);
 	sidesizer->Add(town_choice, 0, wxEXPAND);
 
-	house_list = newd wxListBox(this, PALETTE_HOUSE_LISTBOX, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_SINGLE | wxLB_NEEDED_SB | wxLB_SORT);
+	house_list = newd wxListBox(this, PALETTE_HOUSE_LISTBOX, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_SINGLE | wxLB_NEEDED_SB);
 	sidesizer->Add(house_list, 1, wxEXPAND);
 
 	tmpsizer = newd wxBoxSizer(wxHORIZONTAL);

--- a/source/palette_house.h
+++ b/source/palette_house.h
@@ -69,6 +69,11 @@ public:
 	void OnClickEditHouse(wxCommandEvent& event);
 	void OnClickRemoveHouse(wxCommandEvent& event);
 
+	#ifdef __APPLE__
+	//Used for detecting a deselect
+	void OnListBoxClick(wxMouseEvent& event);
+	#endif
+
 protected:
 	Map* map;
 	wxChoice* town_choice;


### PR DESCRIPTION
Problems with editing houses on macOS have been fixed. Buttons do properly get disabled when they are not needed.