### PR TITLE
 Implements flood fill in Terrain Brush. 

### DIFF
--- a/source/map_display.h
+++ b/source/map_display.h
@@ -51,6 +51,7 @@ public:
 	void OnMouseRightRelease(wxMouseEvent& event);
 
 	void OnKeyDown(wxKeyEvent& event);
+	void OnKeyUp(wxKeyEvent& event);
 	void OnWheel(wxMouseEvent& event);
 	void OnGainMouse(wxMouseEvent& event);
 	void OnLoseMouse(wxMouseEvent& event);
@@ -111,13 +112,20 @@ public:
 	Position GetCursorPosition() const;
 
 	void TakeScreenshot(wxFileName path, wxString format);
-protected:
 
-	void getTilesToDraw(int mouse_map_x, int mouse_map_y, int floor, PositionVector* tilestodraw, PositionVector* tilestoborder);
+protected:
+	void getTilesToDraw(int mouse_map_x, int mouse_map_y, int floor, PositionVector* tilestodraw, PositionVector* tilestoborder, bool fill = false);
+	void floodFill(Map *map, const Position& center, int x, int y, GroundBrush* brush, PositionVector* positions);
 
 private:
+	inline int getFillIndex(int x, int y) const { return x + BLOCK_SIZE * y; }
+
+	static const int BLOCK_SIZE = 100;
+	static bool processed[BLOCK_SIZE*BLOCK_SIZE];
+
 	Editor& editor;
 	MapDrawer *drawer;
+	int keyCode;
 
 // View related
 	int floor;

--- a/source/map_display.h
+++ b/source/map_display.h
@@ -118,9 +118,12 @@ protected:
 	void floodFill(Map *map, const Position& center, int x, int y, GroundBrush* brush, PositionVector* positions);
 
 private:
+	enum {
+		BLOCK_SIZE = 100
+	};
+
 	inline int getFillIndex(int x, int y) const { return x + BLOCK_SIZE * y; }
 
-	static const int BLOCK_SIZE = 100;
 	static bool processed[BLOCK_SIZE*BLOCK_SIZE];
 
 	Editor& editor;


### PR DESCRIPTION
Flood fill is like a paint bucket to fill empty areas or replace ground. 
The area is limited to 100x100 tiles, so some times more clicks will be required to fill the entire area.

**Create a circle**
![image1](https://image.prntscr.com/image/E3kzML2lQ72dfg-EJ5oCDg.png)

**Select other Ground Brush, Ctrl+D an click inside area**
![image2](https://image.prntscr.com/image/fQ1UTXNHTsmMEGyQVc_9nw.png)

**Select other Ground Brush, Ctrl+D an click inside area to replace the current ground**
![image2](https://image.prntscr.com/image/Rn5dcE6dQt_NL9TXtadVuA.png)

## **Known Issue:**

After fill a area and undo the action, empty tiles are observed, however they are not saved with the map.

**A normal area without tile**
![image2](https://image.prntscr.com/image/nM-3W9j5R5KVv4fqdYwY4w.png)

**A area after fill and undo**
![image2](https://image.prntscr.com/image/gCeK_YgvREGf5EPcEn806w.png)