### PR TITLE
[Bug] Fixes crash when saving the map with spawn place set to position without tile

### DIFF
--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1459,7 +1459,7 @@ bool IOMapOTBM::saveSpawns(Map& map, pugi::xml_document& doc)
 	pugi::xml_node spawnNodes = doc.append_child("spawns");
 	for(const auto& spawnPosition : map.spawns) {
 		Tile* tile = map.getTile(spawnPosition);
-		if(tile == NULL)
+		if (tile != nullptr && tile->spawn != nullptr && tile->hasGround())
 			continue;
 		ASSERT(tile);
 		Spawn* spawn = tile->spawn;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1459,7 +1459,7 @@ bool IOMapOTBM::saveSpawns(Map& map, pugi::xml_document& doc)
 	pugi::xml_node spawnNodes = doc.append_child("spawns");
 	for(const auto& spawnPosition : map.spawns) {
 		Tile* tile = map.getTile(spawnPosition);
-		if (tile != nullptr && tile->spawn != nullptr && tile->hasGround())
+		if(tile == NULL)
 			continue;
 		ASSERT(tile);
 		Spawn* spawn = tile->spawn;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1459,6 +1459,8 @@ bool IOMapOTBM::saveSpawns(Map& map, pugi::xml_document& doc)
 	pugi::xml_node spawnNodes = doc.append_child("spawns");
 	for(const auto& spawnPosition : map.spawns) {
 		Tile* tile = map.getTile(spawnPosition);
+		if(tile == NULL)
+			continue;
 		ASSERT(tile);
 		Spawn* spawn = tile->spawn;
 		ASSERT(spawn);


### PR DESCRIPTION
- Adds check when saving the map to not crash when the map has some
spawn position set to a place where there isn't any tile.

Attached map to test.

[crash.map.tar.gz](https://github.com/hjnilsson/rme/files/2275891/crash.map.tar.gz)


Signed-off-by: Renato Foot <costallat@hotmail.com>