### PR TITLE
[Bug] Fixes crash when selecting chest item but close the window instead of selecting some item

### DIFF
--- a/source/complexitem.cpp
+++ b/source/complexitem.cpp
@@ -42,7 +42,8 @@ Item* Container::deepCopy() const
 	Container* copyContainer = dynamic_cast<Container*>(copy);
 	if(copyContainer) {
 		for(Item* item : contents) {
-			copyContainer->contents.push_back(item->deepCopy());
+			if(item != NULL)
+				copyContainer->contents.push_back(item->deepCopy());
 		}
 	}
 	return copy;


### PR DESCRIPTION

Open the chest, try to select one item, but instead of selecting one, close de window and close the chest window.

[test_map.tar.gz](https://github.com/hjnilsson/rme/files/2280609/test_map.tar.gz)


Signed-off-by: Renato Foot Guimarães Costallat <renato.costallat@gmail.com>