### PR TITLE
Selection using slow data structure

### DIFF
--- a/source/copybuffer.cpp
+++ b/source/copybuffer.cpp
@@ -72,7 +72,7 @@ void CopyBuffer::copy(Editor& editor, int floor)
 	int item_count = 0;
 	copyPos = Position(0xFFFF, 0xFFFF, floor);
 
-	for(TileVector::iterator it = editor.selection.begin(); it != editor.selection.end(); ++it) {
+	for(TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); ++it) {
 		++tile_count;
 
 		Tile* tile = *it;
@@ -131,7 +131,7 @@ void CopyBuffer::cut(Editor& editor, int floor)
 
 	PositionList tilestoborder;
 
-	for(TileVector::iterator it = editor.selection.begin(); it != editor.selection.end(); ++it) {
+	for(TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); ++it) {
 		tile_count++;
 
 		Tile* tile = *it;

--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -357,7 +357,7 @@ bool Editor::exportSelectionAsMiniMap(FileName directory, wxString fileName)
 	int min_x = MAP_MAX_WIDTH + 1, min_y = MAP_MAX_HEIGHT + 1, min_z = MAP_MAX_LAYER + 1;
 	int max_x = 0, max_y = 0, max_z = 0;
 
-	const TileVector& tiles = selection.getTiles();
+	const TileSet& tiles = selection.getTiles();
 	for(Tile* tile : tiles) {
 		if(tile->empty())
 			continue;
@@ -963,10 +963,10 @@ void Editor::moveSelection(Position offset)
 	// Remove tiles from the map
 	action = actionQueue->createAction(batchAction); // Our action!
 	bool doborders = false;
-	TileVector tmp_storage;
+	TileSet tmp_storage;
 
 	// Update the tiles with the newd positions
-	for(TileVector::iterator it = selection.begin(); it != selection.end(); ++it) {
+	for(TileSet::iterator it = selection.begin(); it != selection.end(); ++it) {
 		// First we get the old tile and it's position
 		Tile* tile = (*it);
 		//const Position pos = tile->getPosition();
@@ -1007,7 +1007,7 @@ void Editor::moveSelection(Position offset)
 			doborders = true;
 		}
 
-		tmp_storage.push_back(tmp_storage_tile);
+		tmp_storage.insert(tmp_storage_tile);
 		// Add the tile copy to the action
 		action->addChange(newd Change(new_src_tile));
 	}
@@ -1021,7 +1021,7 @@ void Editor::moveSelection(Position offset)
 		action = actionQueue->createAction(batchAction);
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for(TileVector::iterator it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
+		for(TileSet::iterator it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours
 			Tile* t;
@@ -1055,7 +1055,7 @@ void Editor::moveSelection(Position offset)
 
 	// New action for adding the destination tiles
 	action = actionQueue->createAction(batchAction);
-	for(TileVector::iterator it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
+	for(TileSet::iterator it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
 		Tile* tile = (*it);
 		const Position old_pos = tile->getPosition();
 		Position new_pos;
@@ -1099,7 +1099,7 @@ void Editor::moveSelection(Position offset)
 		action = actionQueue->createAction(batchAction);
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for(TileVector::iterator it = selection.begin(); it != selection.end(); it++) {
+		for(TileSet::iterator it = selection.begin(); it != selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours
@@ -1159,7 +1159,7 @@ void Editor::destroySelection()
 		BatchAction* batch = actionQueue->createBatch(ACTION_DELETE_TILES);
 		Action* action = actionQueue->createAction(batch);
 
-		for(TileVector::iterator it = selection.begin(); it != selection.end(); ++it) {
+		for(TileSet::iterator it = selection.begin(); it != selection.end(); ++it) {
 			tile_count++;
 
 			Tile* tile = *it;

--- a/source/map_drawer.cpp
+++ b/source/map_drawer.cpp
@@ -508,7 +508,7 @@ void MapDrawer::DrawDraggingShadow()
 
 	// Draw dragging shadow
 	if(!editor.selection.isBusy() && dragging && !options.ingame) {
-		for(TileVector::iterator tit = editor.selection.begin(); tit != editor.selection.end(); tit++) {
+		for(TileSet::iterator tit = editor.selection.begin(); tit != editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rme_forward_declarations.h
+++ b/source/rme_forward_declarations.h
@@ -33,8 +33,11 @@ class Action;
 
 class Brush;
 
+#include <unordered_set>
+
 typedef std::vector<uint32_t> HouseExitList;
 typedef std::vector<Tile*> TileVector;
+typedef std::unordered_set<Tile*> TileSet;
 typedef std::vector<Item*> ItemVector;
 typedef std::vector<Brush*> BrushVector;
 

--- a/source/selection.cpp
+++ b/source/selection.cpp
@@ -226,13 +226,11 @@ void Selection::start(SessionFlags flags)
 		}
 		subsession = editor.actionQueue->createAction(ACTION_SELECT);
 	}
-	erase_iterator = tiles.begin();
 	busy = true;
 }
 
 void Selection::commit()
 {
-	erase_iterator = tiles.begin();
 	if(session) {
 		ASSERT(subsession);
 		// We need to step out of the session before we do the action, else peril awaits us!
@@ -250,7 +248,6 @@ void Selection::commit()
 
 void Selection::finish(SessionFlags flags)
 {
-	erase_iterator = tiles.begin();
 	if(!(flags & INTERNAL)) {
 		if(flags & SUBTHREAD) {
 			ASSERT(subsession);

--- a/source/selection.cpp
+++ b/source/selection.cpp
@@ -44,7 +44,7 @@ Selection::~Selection()
 Position Selection::minPosition() const
 {
 	Position minPos(0x10000, 0x10000, 0x10);
-	for(TileVector::const_iterator tile = tiles.begin(); tile != tiles.end(); ++tile) {
+	for(TileSet::const_iterator tile = tiles.begin(); tile != tiles.end(); ++tile) {
 		Position pos((*tile)->getPosition());
 		if(minPos.x > pos.x)
 			minPos.x = pos.x;
@@ -59,7 +59,7 @@ Position Selection::minPosition() const
 Position Selection::maxPosition() const
 {
 	Position maxPos(0, 0, 0);
-	for(TileVector::const_iterator tile = tiles.begin(); tile != tiles.end(); ++tile) {
+	for(TileSet::const_iterator tile = tiles.begin(); tile != tiles.end(); ++tile) {
 		Position pos((*tile)->getPosition());
 		if(maxPos.x < pos.x)
 			maxPos.x = pos.x;
@@ -191,53 +191,25 @@ void Selection::addInternal(Tile* tile)
 {
 	ASSERT(tile);
 
-	tiles.push_back(tile);
-	erase_iterator = tiles.begin();
+	tiles.insert(tile);
 }
 
 void Selection::removeInternal(Tile* tile)
 {
 	ASSERT(tile);
-#ifdef __DEBUG_MODE__
-	TileVector::iterator erase_begin = erase_iterator;
-#endif
-	if(tiles.size() == 0)
-		return;
-
-	TileVector::iterator end_iter = tiles.end();
-	do {
-		if(erase_iterator == end_iter) {
-			erase_iterator = tiles.begin();
-		}
-		if(*erase_iterator == tile) {
-			// Swap & pop trick
-			if(*erase_iterator == tiles.back()) {
-				tiles.pop_back();
-				erase_iterator = tiles.begin();
-			} else {
-				std::swap(*erase_iterator, tiles.back());
-				tiles.pop_back();
-				erase_iterator = tiles.begin() + (erase_iterator - tiles.begin());
-			}
-			return;
-		}
-		++erase_iterator;
-#ifdef __DEBUG_MODE__
-		ASSERT(/* This shouldn't happend*/ erase_iterator != erase_begin);
-#endif
-	} while(true);
+	tiles.erase(tile);
 }
 
 void Selection::clear()
 {
 	if(session) {
-		for(TileVector::iterator it = tiles.begin(); it != tiles.end(); it++) {
+		for(TileSet::iterator it = tiles.begin(); it != tiles.end(); it++) {
 			Tile* new_tile = (*it)->deepCopy(editor.map);
 			new_tile->deselect();
 			subsession->addChange(newd Change(new_tile));
 		}
 	} else {
-		for(TileVector::iterator it = tiles.begin(); it != tiles.end(); it++) {
+		for(TileSet::iterator it = tiles.begin(); it != tiles.end(); it++) {
 			(*it)->deselect();
 		}
 		tiles.clear();

--- a/source/selection.h
+++ b/source/selection.h
@@ -78,7 +78,6 @@ private:
 	Action* subsession;
 
 	TileSet tiles;
-	TileSet::iterator erase_iterator;
 
 	friend class SelectionThread;
 };

--- a/source/selection.h
+++ b/source/selection.h
@@ -66,10 +66,10 @@ public:
 	size_t size() {return tiles.size();}
 	size_t size() const {return tiles.size();}
 	void updateSelectionCount();
-	TileVector::iterator begin() {return tiles.begin();}
-	TileVector::iterator end() {return tiles.end();}
-	TileVector& getTiles() {return tiles; }
-	Tile* getSelectedTile() {ASSERT(size() == 1); return tiles.front();}
+	TileSet::iterator begin() {return tiles.begin();}
+	TileSet::iterator end() {return tiles.end();}
+	TileSet& getTiles() {return tiles; }
+	Tile* getSelectedTile() {ASSERT(size() == 1); return *tiles.begin();}
 
 private:
 	bool busy;
@@ -77,8 +77,8 @@ private:
 	BatchAction* session;
 	Action* subsession;
 
-	TileVector tiles;
-	TileVector::iterator erase_iterator;
+	TileSet tiles;
+	TileSet::iterator erase_iterator;
 
 	friend class SelectionThread;
 };

--- a/source/tile.h
+++ b/source/tile.h
@@ -23,6 +23,7 @@
 #include "position.h"
 #include "item.h"
 #include "map_region.h"
+#include <unordered_set>
 
 enum {
 	TILESTATE_NONE           = 0x0000,
@@ -225,6 +226,7 @@ bool tilePositionLessThan(const Tile* a, const Tile* b);
 bool tilePositionVisualLessThan(const Tile* a, const Tile* b);
 
 typedef std::vector<Tile*> TileVector;
+typedef std::unordered_set<Tile*> TileSet;
 typedef std::list<Tile*> TileList;
 
 inline bool Tile::hasWall() const {


### PR DESCRIPTION
Changed TileVector to TileSet, using unordered set under hood is much faster, removing elements expected complexity O(1) instead of O(n).
Fixes #234 