### PR TITLE
Fix behavior of NodeFileWriteHandle::endNode

### DIFF
--- a/source/filehandle.cpp
+++ b/source/filehandle.cpp
@@ -693,10 +693,10 @@ bool NodeFileWriteHandle::addNode(uint8_t nodetype)
 
 bool NodeFileWriteHandle::endNode()
 {
+	cache[local_write_index++] = NODE_END;
 	if(local_write_index >= cache_size) {
 		renewCache();
 	}
-	cache[local_write_index++] = NODE_END;
 
 	return error_code == FILE_NO_ERROR;
 }


### PR DESCRIPTION
The methods addNode, endNode and writeBytes should employ similar behavior as to renewing the cache.
When writing to the cache in endNode the cache size might be exceeded causing the first byte written by a consecutive addNode or writeBytes to be lost.