### PR TITLE
Support pasting positions in the item property window, and refactor e…

### DIFF
--- a/source/common.cpp
+++ b/source/common.cpp
@@ -21,8 +21,6 @@
 
 #include "common.h"
 #include "math.h"
-#include "gui.h"
-#include "editor.h"
 
 #include <sstream>
 #include <random>

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -24,6 +24,10 @@
 
 #include <sstream>
 #include <random>
+#include <regex>
+#include "gui.h"
+#include "editor.h"
+#include <algorithm>
 
 // random generator
 std::mt19937& getRandomGenerator()
@@ -198,41 +202,52 @@ std::string wstring2string(const std::wstring& widestring)
 	return std::string((const char*)s.mb_str(wxConvUTF8));
 }
 
-bool posFromClipboard(int& x, int& y, int& z)
+bool posFromClipboard(Position& position)
 {
 	bool done = false;
 
-	if(wxTheClipboard->Open()) {
-		if(wxTheClipboard->IsSupported(wxDF_TEXT)) {
-			std::vector<int> values;
+	if (wxTheClipboard->Open()) {
+		if (wxTheClipboard->IsSupported(wxDF_TEXT)) {
+			static const std::regex exprs[] = {
+				// {x = 0, y = 0, z = 0}
+				std::regex(R"(\{x=(\d+),y=(\d+),z=(\d+)\})"),
+				// {"x": 0, "y": 0, "z": 0}
+				std::regex(R"(\{\"x\":(\d+),\"y\":(\d+),\"z\":(\d+)\})"),
+				// x, y, z
+				std::regex(R"((\d+),(\d+),(\d+))"),
+				// (x, y, z)
+				std::regex(R"(\((\d+),(\d+),(\d+)\))"),
+				// Position(x, y, z)
+				std::regex(R"(Position\((\d+),(\d+),(\d+)\))"),
+			};
+
 			wxTextDataObject data;
 			wxTheClipboard->GetData(data);
-			wxString text = data.GetText();
 
-			if(text.size() < 50) {
-				bool r = false;
-				wxString sv;
-
-				for(size_t s = 0; s < text.size(); ++s) {
-					if(text[s] >= '0' && text[s] <= '9') {
-						sv << text[s];
-						r = true;
-					} else if(r) {
-						values.push_back(ws2i(sv));
-						sv.Clear();
-						r = false;
-
-						if(values.size() >= 3)
-							break;
-					}
-				}
+			std::string input = data.GetText().ToStdString();
+			if (!input.empty()) {
+				input.erase(std::remove_if(input.begin(), input.end(), [](const auto &ch) -> bool {
+					return std::isspace(ch);
+				}), input.end());
 			}
 
-			if(values.size() == 3) {
-				x = values[0];
-				y = values[1];
-				z = values[2];
-				done = true;
+			std::smatch matches;
+			for (const auto &expr : exprs) {
+				if (std::regex_match(input, matches, expr)) {
+					const int tmpX = std::stoi(matches.str(1));
+					const int tmpY = std::stoi(matches.str(2));
+					const int tmpZ = std::stoi(matches.str(3));
+
+					if (const Position(tmpX, tmpY, tmpZ).isValid() &&
+						tmpX <= g_gui.GetCurrentEditor()->map.getWidth() &&
+						tmpY <= g_gui.GetCurrentEditor()->map.getHeight()) {
+						position.x = tmpX;
+						position.y = tmpY;
+						position.z = tmpZ;
+						done = true;
+					}
+					break;
+				}
 			}
 		}
 		wxTheClipboard->Close();

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -240,18 +240,21 @@ bool posFromClipboard(Position& position, const int& mapWidth, const int& mapHei
 	std::smatch matches;
 	for(const auto &expr : exprs) {
 		if(std::regex_match(input, matches, expr)) {
-			const int tmpX = std::stoi(matches.str(1));
-			const int tmpY = std::stoi(matches.str(2));
-			const int tmpZ = std::stoi(matches.str(3));
+			try {
+				const int tmpX = std::stoi(matches.str(1));
+				const int tmpY = std::stoi(matches.str(2));
+				const int tmpZ = std::stoi(matches.str(3));
 
-			if(const Position(tmpX, tmpY, tmpZ).isValid() &&
-				tmpX <= mapWidth &&
-				tmpY <= mapHeight) {
-				position.x = tmpX;
-				position.y = tmpY;
-				position.z = tmpZ;
-				done = true;
+				if(const Position(tmpX, tmpY, tmpZ).isValid() &&
+					tmpX <= mapWidth &&
+					tmpY <= mapHeight) {
+					position.x = tmpX;
+					position.y = tmpY;
+					position.z = tmpZ;
+					done = true;
+				}
 			}
+			catch(const std::out_of_range&) {}
 			break;
 		}
 	}

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -200,7 +200,7 @@ std::string wstring2string(const std::wstring& widestring)
 	return std::string((const char*)s.mb_str(wxConvUTF8));
 }
 
-bool posFromClipboard(Position& position, const int& mapWidth, const int& mapHeight)
+bool posFromClipboard(Position& position, const int& mapWidth /* = MAP_MAX_WIDTH */, const int& mapHeight /* = MAP_MAX_HEIGHT */)
 {
 	if(!wxTheClipboard->Open())
 		return false;

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -21,12 +21,12 @@
 
 #include "common.h"
 #include "math.h"
+#include "gui.h"
+#include "editor.h"
 
 #include <sstream>
 #include <random>
 #include <regex>
-#include "gui.h"
-#include "editor.h"
 #include <algorithm>
 
 // random generator

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -228,10 +228,8 @@ bool posFromClipboard(Position& position, const int& mapWidth /* = MAP_MAX_WIDTH
 		std::regex(R"(\{x=(\d+),y=(\d+),z=(\d+)\})"),
 		// {"x": 0, "y": 0, "z": 0}
 		std::regex(R"(\{\"x\":(\d+),\"y\":(\d+),\"z\":(\d+)\})"),
-		// x, y, z
-		std::regex(R"((\d+),(\d+),(\d+))"),
-		// (x, y, z)
-		std::regex(R"(\((\d+),(\d+),(\d+)\))"),
+		// x, y, z & (x, y, z)
+		std::regex(R"(\(?(\d+),(\d+),(\d+)\)?)"),
 		// Position(x, y, z)
 		std::regex(R"(Position\((\d+),(\d+),(\d+)\))"),
 	};

--- a/source/common.cpp
+++ b/source/common.cpp
@@ -202,7 +202,7 @@ std::string wstring2string(const std::wstring& widestring)
 	return std::string((const char*)s.mb_str(wxConvUTF8));
 }
 
-bool posFromClipboard(Position& position)
+bool posFromClipboard(Position& position, const int& mapWidth, const int& mapHeight)
 {
 	if(!wxTheClipboard->Open())
 		return false;
@@ -247,8 +247,8 @@ bool posFromClipboard(Position& position)
 			const int tmpZ = std::stoi(matches.str(3));
 
 			if(const Position(tmpX, tmpY, tmpZ).isValid() &&
-				tmpX <= g_gui.GetCurrentEditor()->map.getWidth() &&
-				tmpY <= g_gui.GetCurrentEditor()->map.getHeight()) {
+				tmpX <= mapWidth &&
+				tmpY <= mapHeight) {
 				position.x = tmpX;
 				position.y = tmpY;
 				position.z = tmpZ;

--- a/source/common.h
+++ b/source/common.h
@@ -60,7 +60,7 @@ std::wstring string2wstring(const std::string& utf8string);
 std::string wstring2string(const std::wstring& widestring);
 
 // Gets position values from ClipBoard
-bool posFromClipboard(Position& position, const int& mapWidth, const int& mapHeight);
+bool posFromClipboard(Position& position, const int& mapWidth = MAP_MAX_WIDTH, const int& mapHeight = MAP_MAX_HEIGHT);
 
 // Returns 'yes' if the defined value is true or 'no' if it is false.
 wxString b2yn(bool v);

--- a/source/common.h
+++ b/source/common.h
@@ -60,7 +60,7 @@ std::wstring string2wstring(const std::string& utf8string);
 std::string wstring2string(const std::wstring& widestring);
 
 // Gets position values from ClipBoard
-bool posFromClipboard(int& x, int& y, int& z);
+bool posFromClipboard(Position& position);
 
 // Returns 'yes' if the defined value is true or 'no' if it is false.
 wxString b2yn(bool v);

--- a/source/common.h
+++ b/source/common.h
@@ -60,7 +60,7 @@ std::wstring string2wstring(const std::string& utf8string);
 std::string wstring2string(const std::wstring& widestring);
 
 // Gets position values from ClipBoard
-bool posFromClipboard(Position& position);
+bool posFromClipboard(Position& position, const int& mapWidth, const int& mapHeight);
 
 // Returns 'yes' if the defined value is true or 'no' if it is false.
 wxString b2yn(bool v);

--- a/source/main_toolbar.cpp
+++ b/source/main_toolbar.cpp
@@ -489,8 +489,8 @@ void MainToolBar::OnPositionButtonClick(wxCommandEvent& event)
 void MainToolBar::OnPastePositionText(wxClipboardTextEvent& event)
 {
 	Position position;
-	Map& map = g_gui.GetCurrentEditor()->map;
-	if (posFromClipboard(position, map.getWidth(), map.getHeight())) {
+	Editor* editor = g_gui.GetCurrentEditor();
+	if (posFromClipboard(position, editor->getMapWidth(), editor->getMapHeight())) {
 		x_control->SetIntValue(position.x);
 		y_control->SetIntValue(position.y);
 		z_control->SetIntValue(position.z);

--- a/source/main_toolbar.cpp
+++ b/source/main_toolbar.cpp
@@ -489,7 +489,8 @@ void MainToolBar::OnPositionButtonClick(wxCommandEvent& event)
 void MainToolBar::OnPastePositionText(wxClipboardTextEvent& event)
 {
 	Position position;
-	if (posFromClipboard(position.x, position.y, position.z)) {
+	Map& map = g_gui.GetCurrentEditor()->map;
+	if (posFromClipboard(position, map.getWidth(), map.getHeight())) {
 		x_control->SetIntValue(position.x);
 		y_control->SetIntValue(position.y);
 		z_control->SetIntValue(position.z);

--- a/source/old_properties_window.cpp
+++ b/source/old_properties_window.cpp
@@ -656,7 +656,8 @@ void OldPropertiesWindow::OnChar(wxKeyEvent &evt)
 	if (evt.GetKeyCode() == WXK_CONTROL_V)
 	{
 		Position position;
-		if (posFromClipboard(position)) {
+		Map& map = g_gui.GetCurrentEditor()->map;
+		if (posFromClipboard(position, map.getWidth(), map.getHeight())) {
 			x_field->SetValue(position.x);
 			y_field->SetValue(position.y);
 			z_field->SetValue(position.z);

--- a/source/old_properties_window.cpp
+++ b/source/old_properties_window.cpp
@@ -292,13 +292,18 @@ OldPropertiesWindow::OldPropertiesWindow(wxWindow* win_parent, const Map* map, c
 
 		if(teleport) {
 			subsizer->Add(newd wxStaticText(this, wxID_ANY, "Destination"));
-
 			wxSizer* possizer = newd wxBoxSizer(wxHORIZONTAL);
+
 			x_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(teleport->getX()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, map->getWidth(), teleport->getX());
+			x_field->Bind(wxEVT_CHAR, &OldPropertiesWindow::OnChar, this);
 			possizer->Add(x_field, wxSizerFlags(3).Expand());
+
 			y_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(teleport->getY()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, map->getHeight(), teleport->getY());
+			y_field->Bind(wxEVT_CHAR, &OldPropertiesWindow::OnChar, this);
 			possizer->Add(y_field, wxSizerFlags(3).Expand());
+
 			z_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(teleport->getZ()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, MAP_MAX_LAYER, teleport->getZ());
+			z_field->Bind(wxEVT_CHAR, &OldPropertiesWindow::OnChar, this);
 			possizer->Add(z_field, wxSizerFlags(2).Expand());
 
 			subsizer->Add(possizer, wxSizerFlags(1).Expand());
@@ -644,4 +649,20 @@ void OldPropertiesWindow::Update()
 		}
 	}
 	wxDialog::Update();
+}
+
+void OldPropertiesWindow::OnChar(wxKeyEvent &evt)
+{
+	if (evt.GetKeyCode() == WXK_CONTROL_V)
+	{
+		Position position;
+		if (posFromClipboard(position)) {
+			x_field->SetValue(position.x);
+			y_field->SetValue(position.y);
+			z_field->SetValue(position.z);
+			return;
+		}
+	}
+
+	evt.Skip();
 }

--- a/source/old_properties_window.cpp
+++ b/source/old_properties_window.cpp
@@ -656,8 +656,8 @@ void OldPropertiesWindow::OnChar(wxKeyEvent &evt)
 	if (evt.GetKeyCode() == WXK_CONTROL_V)
 	{
 		Position position;
-		Map& map = g_gui.GetCurrentEditor()->map;
-		if (posFromClipboard(position, map.getWidth(), map.getHeight())) {
+		Editor* editor = g_gui.GetCurrentEditor();
+		if (posFromClipboard(position, editor->getMapWidth(), editor->getMapHeight())) {
 			x_field->SetValue(position.x);
 			y_field->SetValue(position.y);
 			z_field->SetValue(position.z);

--- a/source/old_properties_window.h
+++ b/source/old_properties_window.h
@@ -25,6 +25,8 @@ public:
 	void OnClickOK(wxCommandEvent&);
 	void OnClickCancel(wxCommandEvent&);
 
+	void OnChar(wxKeyEvent &evt);
+
 	void Update();
 
 protected:

--- a/source/positionctrl.cpp
+++ b/source/positionctrl.cpp
@@ -68,8 +68,8 @@ bool PositionCtrl::Enable(bool enable)
 void PositionCtrl::OnClipboardText(wxClipboardTextEvent& evt)
 {
 	Position position;
-	Map& map = g_gui.GetCurrentEditor()->map;
-	if (posFromClipboard(position, map.getWidth(), map.getHeight())) {
+	Editor* editor = g_gui.GetCurrentEditor();
+	if (posFromClipboard(position, editor->getMapWidth(), editor->getMapHeight())) {
 		x_field->SetIntValue(position.x);
 		y_field->SetIntValue(position.y);
 		z_field->SetIntValue(position.z);

--- a/source/positionctrl.cpp
+++ b/source/positionctrl.cpp
@@ -19,6 +19,8 @@
 #include "positionctrl.h"
 #include "numbertextctrl.h"
 #include "position.h"
+#include "gui.h"
+#include "editor.h"
 
 PositionCtrl::PositionCtrl(wxWindow* parent, const wxString& label, int x, int y, int z,
 	int maxx /*= MAP_MAX_WIDTH*/, int maxy /*= MAP_MAX_HEIGHT*/, int maxz /*= MAP_MAX_LAYER*/) :
@@ -66,7 +68,8 @@ bool PositionCtrl::Enable(bool enable)
 void PositionCtrl::OnClipboardText(wxClipboardTextEvent& evt)
 {
 	Position position;
-	if (posFromClipboard(position)) {
+	Map& map = g_gui.GetCurrentEditor()->map;
+	if (posFromClipboard(position, map.getWidth(), map.getHeight())) {
 		x_field->SetIntValue(position.x);
 		y_field->SetIntValue(position.y);
 		z_field->SetIntValue(position.z);

--- a/source/positionctrl.cpp
+++ b/source/positionctrl.cpp
@@ -66,7 +66,7 @@ bool PositionCtrl::Enable(bool enable)
 void PositionCtrl::OnClipboardText(wxClipboardTextEvent& evt)
 {
 	Position position;
-	if(posFromClipboard(position.x, position.y, position.z)) {
+	if (posFromClipboard(position)) {
 		x_field->SetIntValue(position.x);
 		y_field->SetIntValue(position.y);
 		z_field->SetIntValue(position.z);

--- a/source/positionctrl.cpp
+++ b/source/positionctrl.cpp
@@ -19,8 +19,6 @@
 #include "positionctrl.h"
 #include "numbertextctrl.h"
 #include "position.h"
-#include "gui.h"
-#include "editor.h"
 
 PositionCtrl::PositionCtrl(wxWindow* parent, const wxString& label, int x, int y, int z,
 	int maxx /*= MAP_MAX_WIDTH*/, int maxy /*= MAP_MAX_HEIGHT*/, int maxz /*= MAP_MAX_LAYER*/) :
@@ -37,6 +35,9 @@ wxStaticBoxSizer(wxHORIZONTAL, parent, label)
 	z_field = newd NumberTextCtrl(parent, wxID_ANY, z, 0, maxz, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, wxSize(35, 20));
 	z_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(z_field, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	maxWidth = maxx;
+	maxHeight = maxy;
 }
 
 PositionCtrl::~PositionCtrl()
@@ -68,8 +69,7 @@ bool PositionCtrl::Enable(bool enable)
 void PositionCtrl::OnClipboardText(wxClipboardTextEvent& evt)
 {
 	Position position;
-	Editor* editor = g_gui.GetCurrentEditor();
-	if (posFromClipboard(position, editor->getMapWidth(), editor->getMapHeight())) {
+	if (posFromClipboard(position, maxWidth, maxHeight)) {
 		x_field->SetIntValue(position.x);
 		y_field->SetIntValue(position.y);
 		z_field->SetIntValue(position.z);

--- a/source/positionctrl.h
+++ b/source/positionctrl.h
@@ -45,6 +45,9 @@ protected:
 	NumberTextCtrl* x_field;
 	NumberTextCtrl* y_field;
 	NumberTextCtrl* z_field;
+
+private:
+	int maxWidth, maxHeight;
 };
 
 #endif


### PR DESCRIPTION
…xtracting positions from the clipboard

This will also improve pasting positions in the "Go to Position" window (CTRL +G)

Note: Pasting a position via the context menu in the item properties window is not supported, as the SpinCtrl doesn't emit a suitable event for pasting text, I have asked about it here: https://forums.wxwidgets.org/viewtopic.php?f=1&t=46035