### PR TITLE
Explicit fallthrough per C++17 to quiet GCC

### DIFF
--- a/source/common_windows.cpp
+++ b/source/common_windows.cpp
@@ -692,6 +692,7 @@ void FindDialog::OnKeyDown(wxKeyEvent& event)
 	switch(event.GetKeyCode()) {
 		case WXK_PAGEUP:
 			amount = h / 32 + 1;
+			[[fallthrough]];
 		case WXK_UP: {
 			if(item_list->GetItemCount() > 0) {
 				ssize_t n = item_list->GetSelection();
@@ -708,6 +709,7 @@ void FindDialog::OnKeyDown(wxKeyEvent& event)
 
 		case WXK_PAGEDOWN:
 			amount = h / 32 + 1;
+			[[fallthrough]];
 		case WXK_DOWN: {
 			if(item_list->GetItemCount() > 0) {
 				ssize_t n = item_list->GetSelection();
@@ -976,6 +978,7 @@ void ReplaceItemDialog::OnKeyDown(wxKeyEvent& event)
 	switch(event.GetKeyCode()) {
 		case WXK_PAGEUP:
 			amount = h / 32 + 1;
+			[[fallthrough]];
 		case WXK_UP: {
 			if(item_list->GetItemCount() > 0) {
 				ssize_t n = item_list->GetSelection();
@@ -991,6 +994,7 @@ void ReplaceItemDialog::OnKeyDown(wxKeyEvent& event)
 		}
 		case WXK_PAGEDOWN:
 			amount = h / 32 + 1;
+			[[fallthrough]];
 		case WXK_DOWN: {
 			if(item_list->GetItemCount() > 0) {
 				ssize_t n = item_list->GetSelection();

--- a/source/palette_brushlist.cpp
+++ b/source/palette_brushlist.cpp
@@ -596,6 +596,7 @@ void BrushListBox::OnKey(wxKeyEvent& event)
 		case WXK_END:
 			event.Skip(true);
 			} else {
+			[[fallthrough]];
 		default:
 			if(g_gui.GetCurrentTab() != nullptr) {
 				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);


### PR DESCRIPTION
This is to comply with the new standards and quash compiler warnings by fixing rather than suppressing.

Further reading available:
[-Wimplicit-fallthrough in GCC 7](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/)
[C++ attribute: fallthrough (since C++17)](https://en.cppreference.com/w/cpp/language/attributes/fallthrough)