### PR TITLE
Performance Optimization & Teleport 'Open Door' fix

### DIFF
--- a/source/map_display.cpp
+++ b/source/map_display.cpp
@@ -2306,20 +2306,25 @@ void MapPopupMenu::Update()
 
 			if(topSelectedItem || topCreature || topItem) {
 				Teleport* teleport = dynamic_cast<Teleport*>(topSelectedItem);
-				if(topSelectedItem && (topSelectedItem->isBrushDoor() || topSelectedItem->isRoteable() || teleport)) {
-					if(topSelectedItem->isRoteable()) {
-						Append( MAP_POPUP_MENU_ROTATE, "&Rotate item", "Rotate this item");
+				if (topSelectedItem && (topSelectedItem->isBrushDoor() || topSelectedItem->isRoteable() || teleport)) {
+					if (topSelectedItem->isRoteable()) {
+						Append(MAP_POPUP_MENU_ROTATE, "&Rotate item", "Rotate this item");
 					}
 
-					if(teleport && teleport->hasDestination()) {
-						Append( MAP_POPUP_MENU_GOTO, "&Go To Destination", "Go to the destination of this teleport");
+					if (teleport && teleport->hasDestination()) {
+						Append(MAP_POPUP_MENU_GOTO, "&Go To Destination", "Go to the destination of this teleport");
 					}
-					if(topSelectedItem->isOpen()) {
-						Append( MAP_POPUP_MENU_SWITCH_DOOR, "&Close door", "Close this door");
-					} else {
-						Append( MAP_POPUP_MENU_SWITCH_DOOR, "&Open door", "Open this door");
+					if (topSelectedItem->isDoor())
+					{
+						if (topSelectedItem->isOpen()) {
+							Append(MAP_POPUP_MENU_SWITCH_DOOR, "&Close door", "Close this door");
+						}
+						else {
+							Append(MAP_POPUP_MENU_SWITCH_DOOR, "&Open door", "Open this door");
+						}
+						AppendSeparator();
 					}
-					AppendSeparator();
+					
 				}
 
 				if(topCreature)

--- a/source/map_drawer.cpp
+++ b/source/map_drawer.cpp
@@ -283,7 +283,7 @@ void MapDrawer::DrawMap()
 
 					if(!live_client || nd->isVisible(map_z > GROUND_LAYER)) {
 						for(int map_x = 0; map_x < 4; ++map_x) {
-							for(int map_y = 0; map_y < 4; ++map_y) {
+							for (int map_y = 0; map_y < 4; ++map_y) {
 								DrawTile(nd->getTile(map_x, map_y, map_z));
 							}
 						}
@@ -1368,7 +1368,6 @@ void MapDrawer::DrawTile(TileLocation* location)
 	int map_y = location->getY();
 	int map_z = location->getZ();
 
-	std::ostringstream tooltip;
 
 	if(options.show_tooltips && location->getWaypointCount() > 0) {
 		Waypoint* waypoint = canvas->editor.map.waypoints.getWaypoint(location);
@@ -1514,6 +1513,7 @@ void MapDrawer::DrawTile(TileLocation* location)
 		else
 			MakeTooltip(draw_x, draw_y, tooltip.str());
 	}
+	tooltip.str("");
 }
 
 void MapDrawer::DrawBrushIndicator(int x, int y, Brush* brush, uint8_t r, uint8_t g, uint8_t b)

--- a/source/map_drawer.h
+++ b/source/map_drawer.h
@@ -98,6 +98,7 @@ class MapDrawer
 
 protected:
 	std::vector<MapTooltip*> tooltips;
+	std::ostringstream tooltip;
 
 public:
 	MapDrawer(MapCanvas* canvas);


### PR DESCRIPTION
*Adds a minor performance optimization by removing 'tooltip' allocations every time 'DrawTile' is called, this should increase the performance when moving around the map(e.g. using arrow keys when zoomed out), slow computers should benefit the most from this.
The performance increase can be seen in the comparison bellow, where I used the same map, distance from the ground and movement from a specific point to benchmark.

Old code:
https://giphy.com/gifs/dB0lJnX8pfd0UQgJs1

New code:
https://giphy.com/gifs/VGhNvlpWzzsfiPF5fi

*Teleports should no longer have the option to 'Open Door' when right-clicking them. (#313)