### PR TITLE
fix ghost selected items in the browse field

### DIFF
--- a/source/browse_tile_window.cpp
+++ b/source/browse_tile_window.cpp
@@ -50,7 +50,6 @@ protected:
 BrowseTileListBox::BrowseTileListBox(wxWindow* parent, wxWindowID id, Tile* tile) :
 wxVListBox(parent, id, wxDefaultPosition, wxSize(200, 180), wxLB_MULTIPLE), edit_tile(tile)
 {
-	edit_tile->select();
 	UpdateItems();
 }
 
@@ -105,12 +104,11 @@ void BrowseTileListBox::RemoveSelected()
 	items.clear();
 
 	// Delete the items from the tile
-	ItemVector tile_selection = edit_tile->popSelectedItems();
+	ItemVector tile_selection = edit_tile->popSelectedItems(true);
 	for(ItemVector::iterator iit = tile_selection.begin(); iit != tile_selection.end(); ++iit) {
 		delete *iit;
 	}
 
-	edit_tile->select();
 	UpdateItems();
 	Refresh();
 }

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -283,11 +283,11 @@ Item* Tile::getTopSelectedItem()
 	return nullptr;
 }
 
-ItemVector Tile::popSelectedItems()
+ItemVector Tile::popSelectedItems(bool ignoreTileSelected)
 {
 	ItemVector pop_items;
 
-	if(!isSelected()) return pop_items;
+	if(!ignoreTileSelected && !isSelected()) return pop_items;
 
 	if(ground && ground->isSelected()) {
 		pop_items.push_back(ground);

--- a/source/tile.h
+++ b/source/tile.h
@@ -121,7 +121,7 @@ public: //Functions
 	bool isSelected() const { return testFlags(statflags, TILESTATE_SELECTED); }
 	bool hasUniqueItem() const { return testFlags(statflags, TILESTATE_UNIQUE); }
 
-	ItemVector popSelectedItems();
+	ItemVector popSelectedItems(bool ignoreTileSelected = false);
 	ItemVector getSelectedItems();
 	Item* getTopSelectedItem();
 


### PR DESCRIPTION
This code fixes a problem in the browse field when we delete an item and some other items are deleted too, including the tile.

What happens is that when there are many items in the browse field, those that are not shown on the screen are marked as selected, so when `BrowseTileListBox::RemoveSelected` is called, it does not delete only what you have selected, but also these ghost selected items.